### PR TITLE
Allow users to set component names in remote state

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -13,7 +13,7 @@ module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "account-map"
+  component   = var.account_map_component_name
   environment = var.account_map_environment_name
   stage       = var.account_map_stage_name
   tenant      = var.account_map_tenant_name
@@ -25,7 +25,7 @@ module "tgw_hub_this_region" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component = "tgw/hub"
+  component = var.tgw_hub_this_region_component_name
 
   context = module.this.context
 }
@@ -34,7 +34,7 @@ module "tgw_hub_primary_region" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "tgw/hub"
+  component   = var.tgw_hub_primary_region_component_name
   stage       = local.primary_tgw_hub_stage
   environment = local.primary_tgw_hub_environment
   tenant      = local.primary_tgw_hub_tenant

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -48,3 +48,21 @@ variable "account_map_tenant_name" {
   description = "The name of the tenant where `account_map` is provisioned"
   default     = "core"
 }
+
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of the account-map component"
+  default     = "account-map"
+}
+
+variable "tgw_hub_this_region_component_name" {
+  type        = string
+  description = "The component name of the tgw hub in this region"
+  default     = "tgw/hub"
+}
+
+variable "tgw_hub_primary_region_component_name" {
+  type        = string
+  description = "The component name of the tgw hub in the primary region"
+  default     = "tgw/hub"
+}


### PR DESCRIPTION
Allow users to set component names in remote state.

* Defined the input variables `account_map_component_name`, `tgw_hub_this_region_component_name` and `tgw_hub_primary_region_component_name`.
* Variables default to preserving the behavior of the current version.
* Remote state uses these variables to pull in the state of the components.
* This update allows the codebase to adopt more standardized structure and naming practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added configuration options to customize component names for the account map and transit gateway hub (current and primary regions).
  * Defaults preserve existing behavior; no changes required unless you choose to override.
  * Enables environment-specific naming without code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->