### PR TITLE
Renamed component names input variables

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -25,7 +25,8 @@ module "tgw_hub_this_region" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component = var.this_tgw_hub_component_name
+  # Use the first none-null value
+  component = coalesce(var.this_tgw_hub_component_name, var.tgw_hub_this_region_component_name) 
 
   context = module.this.context
 }
@@ -34,7 +35,8 @@ module "tgw_hub_primary_region" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = var.primary_tgw_hub_component_name
+  # Use the first none-null value
+  component   = coalesce(var.primary_tgw_hub_component_name, var.tgw_hub_primary_region_component_name)
   stage       = local.primary_tgw_hub_stage
   environment = local.primary_tgw_hub_environment
   tenant      = local.primary_tgw_hub_tenant

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -13,7 +13,7 @@ module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "account-map"
+  component   = var.account_map_component_name
   environment = var.account_map_environment_name
   stage       = var.account_map_stage_name
   tenant      = var.account_map_tenant_name
@@ -25,7 +25,7 @@ module "tgw_hub_this_region" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component = "tgw/hub"
+  component = var.tgw_hub_this_region_component_name
 
   context = module.this.context
 }
@@ -34,7 +34,7 @@ module "tgw_hub_primary_region" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "tgw/hub"
+  component   = var.tgw_hub_primary_region_component_name
   stage       = local.primary_tgw_hub_stage
   environment = local.primary_tgw_hub_environment
   tenant      = local.primary_tgw_hub_tenant

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -25,7 +25,7 @@ module "tgw_hub_this_region" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component = var.tgw_hub_this_region_component_name
+  component = var.this_tgw_hub_component_name
 
   context = module.this.context
 }
@@ -34,7 +34,7 @@ module "tgw_hub_primary_region" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = var.tgw_hub_primary_region_component_name
+  component   = var.primary_tgw_hub_component_name
   stage       = local.primary_tgw_hub_stage
   environment = local.primary_tgw_hub_environment
   tenant      = local.primary_tgw_hub_tenant

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -31,6 +31,18 @@ variable "primary_tgw_hub_region" {
   description = "The name of the AWS region where the primary Transit Gateway hub is deployed. This value is used with `var.env_naming_convention` to determine the primary Transit Gateway hub's environment name."
 }
 
+variable "primary_tgw_hub_component_name" {
+  type        = string
+  description = "The component name of the primary tgw hub"
+  default     = "tgw/hub"
+}
+
+variable "this_tgw_hub_component_name" {
+  type        = string
+  description = "The component name of this tgw hub"
+  default     = "tgw/hub"
+}
+
 variable "account_map_environment_name" {
   type        = string
   description = "The name of the environment where `account_map` is provisioned"
@@ -55,14 +67,3 @@ variable "account_map_component_name" {
   default     = "account-map"
 }
 
-variable "tgw_hub_this_region_component_name" {
-  type        = string
-  description = "The component name of the tgw hub in this region"
-  default     = "tgw/hub"
-}
-
-variable "tgw_hub_primary_region_component_name" {
-  type        = string
-  description = "The component name of the tgw hub in the primary region"
-  default     = "tgw/hub"
-}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -73,20 +73,20 @@ variable "account_map_component_name" {
 
 variable "tgw_hub_this_region_component_name" {
   type        = string
-  description = <<-EOT
+  description = <<-DOC
     The component name of the tgw hub in this region. 
     Deprecated, use variable `this_tgw_hub_component_name` instead.
     If the `this_tgw_hub_component_name` variable is set (i.e., not null), it takes precedence over the deprecated variable.
-  EOT
+  DOC
   default     = "tgw/hub"
 }
 
 variable "tgw_hub_primary_region_component_name" {
   type        = string
-  description = <<-EOT
+  description = <<-DOC
     The component name of the tgw hub in the primary region. 
     Deprecated, use variable `primary_tgw_hub_component_name` instead.
     If the `primary_tgw_hub_component_name` variable is set (i.e., not null), it takes precedence over the deprecated variable.
-  EOT
+  DOC
   default     = "tgw/hub"
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -48,3 +48,21 @@ variable "account_map_tenant_name" {
   description = "The name of the tenant where `account_map` is provisioned"
   default     = "core"
 }
+
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of the account-map component"
+  default     = "account-map"
+}
+
+variable "tgw_hub_this_region_component_name" {
+  type        = string
+  description = "The component name of the tgw hub in this region"
+  default     = "tgw/hub"
+}
+
+variable "tgw_hub_primary_region_component_name" {
+  type        = string
+  description = "The component name of the tgw hub in the primary region"
+  default     = "tgw/hub"
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -34,13 +34,13 @@ variable "primary_tgw_hub_region" {
 variable "primary_tgw_hub_component_name" {
   type        = string
   description = "The component name of the primary tgw hub"
-  default     = "tgw/hub"
+  default     = null
 }
 
 variable "this_tgw_hub_component_name" {
   type        = string
   description = "The component name of this tgw hub"
-  default     = "tgw/hub"
+  default     = null
 }
 
 variable "account_map_environment_name" {
@@ -67,3 +67,26 @@ variable "account_map_component_name" {
   default     = "account-map"
 }
 
+# -------------------------------------------
+# DEPRECATED INPUTS (kept for compatibility)
+# -------------------------------------------
+
+variable "tgw_hub_this_region_component_name" {
+  type        = string
+  description = <<-EOT
+    The component name of the tgw hub in this region. 
+    Deprecated, use variable `this_tgw_hub_component_name` instead.
+    If the `this_tgw_hub_component_name` variable is set (i.e., not null), it takes precedence over the deprecated variable.
+  EOT
+  default     = "tgw/hub"
+}
+
+variable "tgw_hub_primary_region_component_name" {
+  type        = string
+  description = <<-EOT
+    The component name of the tgw hub in the primary region. 
+    Deprecated, use variable `primary_tgw_hub_component_name` instead.
+    If the `primary_tgw_hub_component_name` variable is set (i.e., not null), it takes precedence over the deprecated variable.
+  EOT
+  default     = "tgw/hub"
+}


### PR DESCRIPTION
Renamed two public Terraform variables and updated remote-state module inputs to reference the new names; deprecated the old variable names (kept for compatibility) with updated descriptions. By default, the old variables continue to work as before.

* Added variable `primary_tgw_hub_component_name`, deprecated `tgw_hub_primary_region_component_name`. 
* Added variable `this_tgw_hub_component_name`, deprecated `tgw_hub_this_region_component_name`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional inputs to specify the component names for the primary and current region hubs. The module now prefers these when provided, maintaining existing behavior by default.
* **Deprecations**
  * Marked the existing hub component name inputs as deprecated. They remain supported but are overridden when the new inputs are set.
* **Documentation**
  * Updated input descriptions with deprecation notices and guidance on precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->