### PR TITLE
feat: add account-map bypass pattern for static account lookups

### DIFF
--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,3 +1,15 @@
+variable "account_map_enabled" {
+  type        = bool
+  description = "Set to true to use the account-map component for account lookups. Set to false to use the static account_map variable."
+  default     = true
+}
+
+variable "account_map" {
+  type        = any
+  description = "Account map to use when account_map_enabled is false. Expected to contain at least 'full_account_map' with account name to ID mappings."
+  default     = {}
+}
+
 provider "aws" {
   region = var.region
 

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -12,9 +12,12 @@ module "account_map" {
   version = "1.8.0"
 
   component   = var.account_map_component_name
-  environment = var.account_map_environment_name
-  stage       = var.account_map_stage_name
-  tenant      = var.account_map_tenant_name
+  environment = var.account_map_enabled ? var.account_map_environment_name : null
+  stage       = var.account_map_enabled ? var.account_map_stage_name : null
+  tenant      = var.account_map_enabled ? coalesce(var.account_map_tenant_name, module.this.tenant) : null
+
+  bypass   = !var.account_map_enabled
+  defaults = var.account_map
 
   context = module.this.context
 }


### PR DESCRIPTION
## What
Add support for bypassing the account-map component lookup when using static account mappings.

## Why
Enables use of this component in environments that don't deploy the account-map component, using static account maps passed via variables instead.

## Changes
- `src/remote-state.tf`: Added bypass pattern to account_map module with conditional environment/stage/tenant
- `src/providers.tf`: Added `account_map_enabled` and `account_map` variables

## Usage
When `account_map_enabled = false`, pass the account map directly:

```yaml
vars:
  account_map_enabled: false
  account_map:
    full_account_map:
      core-network: "123456789012"
      core-auto: "234567890123"
```

## References
- Similar pattern implemented in aws-tgw-hub: https://github.com/cloudposse-terraform-components/aws-tgw-hub/pull/59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configuration toggle to switch between dynamic account mapping and static account configuration
  * Added new variables to support custom account map inputs for enhanced deployment flexibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->